### PR TITLE
Fixed type error with Iris.Connect

### DIFF
--- a/src/lib/index.d.ts
+++ b/src/lib/index.d.ts
@@ -87,7 +87,7 @@ declare namespace Iris {
 
 	export function Init(instance?: BasePlayerGui | GuiBase, eventConnection?: EventLike): void;
 	export function Shutdown(): void;
-	export function Connect(this: typeof Iris, callback: () => unknown | void): void;
+	export function Connect(this: typeof Iris, callback: () => unknown | void): () => void;
 	export function Append(userInstance: GuiObject): void;
 	export function ForceRefresh(): void;
 


### PR DESCRIPTION
The current TypeScript types for `Iris:Connect` do not accurately reflect its intended behavior. Specifically, `Iris:Connect` is supposed to return a disconnect function, but the types fail to account for this. This change updates the types to return the expected disconnect function properly.