### PR TITLE
Update ComputedState to accept State as first argument to match Luau.

### DIFF
--- a/src/lib/index.d.ts
+++ b/src/lib/index.d.ts
@@ -155,7 +155,7 @@ declare namespace Iris {
 
 	export function State<T>(initialState: T): State<T>;
 	export function WeakState<T>(initialState: T): State<T>;
-	export function ComputedState<T, R>(firstState: T, onChangeCallback: (value: T) => R): State<R>;
+	export function ComputedState<T, R>(firstState: State<T>, onChangeCallback: (value: T) => R): State<R>;
 }
 
 /* ------------------------------ IRIS WIDGETS ------------------------------ */


### PR DESCRIPTION
The original ComputedState type was incorrect, as it requires a pre-existing state object to compute the returned value from.